### PR TITLE
Parameterize problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added command-line arguments to application.
+
 ## 0.1.0 - 2023-05-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "humans-and-zombies"
-version = "0.1.0"
+version = "0.2.0-unstable"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,110 @@
 version = 3
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
+name = "clap"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
@@ -25,6 +120,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,10 +150,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "humans-and-zombies"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "colored",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -51,6 +197,38 @@ name = "libc"
 version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
+
+[[package]]
+name = "rustix"
+version = "0.37.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "winapi"
@@ -73,3 +251,69 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "humans-and-zombies"
-version = "0.1.0"
+version = "0.2.0-unstable"
 edition = "2021"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ default = ["color"]
 color = ["dep:colored"]
 
 [dependencies]
+clap = "4.2.7"
 colored = { version = "2.0.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The problem statement, paraphrasing Wikipedia, is this:
 > The boat cannot cross the river by itself with no people on board.
 
 See [`humans_and_zombies.rs`](src/humans_and_zombies.rs) for the problem specifics
-and [`search.rs`](src/search.rs) for the search specifics or simply run `cargo run` and observe a solution:
+and [`search.rs`](src/search.rs) for the search specifics or simply run `cargo run -- humans-and-zombies` and observe a solution:
 
 ```
   HHH ZZZ |B~~~|
@@ -39,6 +39,24 @@ and [`search.rs`](src/search.rs) for the search specifics or simply run `cargo r
       H Z |B~~~| HH ZZ
            H Z →
           |~~~B| HHH ZZZ
+```
+
+You can parameterize the problem. To use only two zombies and a boat with capacity four, run e.g.
+
+```
+cargo run -- humans-and-zombies --humans 3 --zombies 2 --boat 4
+```
+
+Which prints a plan like:
+
+```
+   HHH ZZ |B~~~|
+           HHH →
+       ZZ |~~~B| HHH
+           ← HH
+    HH ZZ |B~~~| H
+           HH ZZ →
+          |~~~B| HHH ZZ
 ```
 
 Result plans differ depending on whether a depth-first (LIFO) or

--- a/src/humans_and_zombies.rs
+++ b/src/humans_and_zombies.rs
@@ -333,8 +333,8 @@ mod tests {
             Boat::new(2, RiverBank::Left),
         );
 
-        let action = WorldAction::new(2, 0).expect("valid action");
+        let action = WorldAction::new(2, 0);
 
-        assert!(is_applicable(&action, &state));
+        assert!(action.is_applicable(&state));
     }
 }

--- a/src/humans_and_zombies.rs
+++ b/src/humans_and_zombies.rs
@@ -1,4 +1,4 @@
-use crate::{Action, State};
+use crate::search::{Action, State};
 use std::fmt::{Debug, Formatter};
 
 /// Describes the world state.
@@ -8,8 +8,8 @@ pub struct WorldState {
     pub left: RiverBankState,
     /// The right river bank.
     pub right: RiverBankState,
-    /// The river bank at which the boat is.
-    pub boat: RiverBank,
+    /// The boat.
+    pub boat: Boat,
 }
 
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -18,6 +18,14 @@ pub enum RiverBank {
     Left,
     /// Right right river bank.
     Right,
+}
+
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct Boat {
+    /// The capacity of the boat.
+    pub capacity: u8,
+    /// The river bank the boat is at.
+    pub bank: RiverBank,
 }
 
 /// Describes the state on a river bank.
@@ -40,14 +48,14 @@ pub struct WorldAction {
 
 impl WorldState {
     /// Creates a new problem state from the left and right river bank states.
-    pub const fn new(left: RiverBankState, right: RiverBankState, boat: RiverBank) -> Self {
+    pub const fn new(left: RiverBankState, right: RiverBankState, boat: Boat) -> Self {
         Self { left, right, boat }
     }
 
     /// Unpacks the world state into a tuple of "this river bank" (i.e.
     /// the bank that the boat is currently at) and "the opposite river bank".
     pub fn here_there(&self) -> (&RiverBankState, &RiverBankState) {
-        match self.boat {
+        match self.boat.bank {
             RiverBank::Left => (&self.left, &self.right),
             RiverBank::Right => (&self.right, &self.left),
         }
@@ -56,7 +64,7 @@ impl WorldState {
     /// Unpacks the world state into a (mutable) tuple of "this river bank" (i.e.
     /// the bank that the boat is currently at) and "the opposite river bank".
     pub fn here_there_mut(&mut self) -> (&mut RiverBankState, &mut RiverBankState) {
-        match self.boat {
+        match self.boat.bank {
             RiverBank::Left => (&mut self.left, &mut self.right),
             RiverBank::Right => (&mut self.right, &mut self.left),
         }
@@ -64,7 +72,7 @@ impl WorldState {
 
     /// Gets the river bank the boat is at.
     pub fn boat_bank(&self) -> &RiverBankState {
-        match self.boat {
+        match self.boat.bank {
             RiverBank::Left => &self.left,
             RiverBank::Right => &self.right,
         }
@@ -75,7 +83,8 @@ impl Default for WorldState {
     fn default() -> Self {
         let left = RiverBankState::new(3, 3);
         let right = RiverBankState::new(0, 0);
-        WorldState::new(left, right, RiverBank::Left)
+        let boat = Boat::new(2, RiverBank::Left);
+        WorldState::new(left, right, boat)
     }
 }
 
@@ -86,6 +95,18 @@ impl Debug for WorldState {
             "{{ left: {:?}, right: {:?}, boat: {:?} }}",
             self.left, self.right, self.boat
         )
+    }
+}
+
+impl Boat {
+    /// Creates a new river bank state from the number of humans and zombies.
+    pub const fn new(capacity: u8, bank: RiverBank) -> Self {
+        Self { capacity, bank }
+    }
+
+    /// Switches from the left bank to the right and vice versa.
+    pub fn switch_bank(&self) -> Self {
+        Self::new(self.capacity, self.bank.switch_bank())
     }
 }
 
@@ -109,11 +130,9 @@ impl Debug for RiverBankState {
 }
 
 impl WorldAction {
-    pub const fn new(humans: u8, zombies: u8) -> Result<Self, ()> {
-        match zombies + humans {
-            1 | 2 => Ok(Self { zombies, humans }),
-            _ => Err(()),
-        }
+    pub fn new(humans: u8, zombies: u8) -> Self {
+        debug_assert_ne!(zombies + humans, 0);
+        Self { zombies, humans }
     }
 }
 
@@ -149,38 +168,30 @@ impl State for WorldState {
         let mut actions = Vec::with_capacity(5);
 
         let bank = self.boat_bank();
-        if bank.humans >= 2 {
-            let action = WorldAction::new(2, 0).expect("invalid action");
+        for h in 1..=bank.humans.min(self.boat.capacity) {
+            let action = WorldAction::new(h, 0);
             if action.is_applicable(self) {
                 actions.push(action);
             }
         }
 
-        if bank.zombies >= 2 {
-            let action = WorldAction::new(0, 2).expect("invalid action");
+        for z in 1..=bank.zombies.min(self.boat.capacity) {
+            let action = WorldAction::new(0, z);
             if action.is_applicable(self) {
                 actions.push(action);
             }
         }
 
-        if bank.humans >= 1 && bank.zombies >= 1 {
-            let action = WorldAction::new(1, 1).expect("invalid action");
-            if action.is_applicable(self) {
-                actions.push(action);
-            }
-        }
+        for h in 1..=self.boat.capacity.min(bank.humans) {
+            'z: for z in 1..=self.boat.capacity.min(bank.zombies) {
+                if h + z > self.boat.capacity {
+                    break 'z;
+                }
 
-        if bank.humans >= 1 {
-            let action = WorldAction::new(1, 0).expect("invalid action");
-            if action.is_applicable(self) {
-                actions.push(action);
-            }
-        }
-
-        if bank.zombies >= 1 {
-            let action = WorldAction::new(0, 1).expect("invalid action");
-            if action.is_applicable(self) {
-                actions.push(action);
+                let action = WorldAction::new(h, z);
+                if action.is_applicable(self) {
+                    actions.push(action);
+                }
             }
         }
 
@@ -189,7 +200,11 @@ impl State for WorldState {
 
     /// Gets the hash of this state.
     fn unique_hash(&self) -> Self::Hash {
-        let boat = if self.boat == RiverBank::Left { 0 } else { 1 };
+        let boat = if self.boat.bank == RiverBank::Left {
+            0
+        } else {
+            1
+        };
         (self.left.zombies as u32) << 16 | (self.left.humans as u32) << 8 | (boat as u32)
     }
 }
@@ -200,6 +215,11 @@ impl Action for WorldAction {
     /// Tests whether an action is applicable in the given (usually current) world state.
     fn is_applicable(&self, state: &Self::State) -> bool {
         let (here, there) = state.here_there();
+
+        // We cannot have more zombies than humans on the boat.
+        if self.humans > 0 && self.zombies > self.humans {
+            return false;
+        }
 
         // We cannot move more people than there are on the current bank.
         if here.humans < self.humans || here.zombies < self.zombies {
@@ -265,7 +285,7 @@ pub fn pretty_print_state(state: &WorldState) -> String {
     buffer.push_str(&bank.trim());
 
     // River bank.
-    if state.boat == RiverBank::Left {
+    if state.boat.bank == RiverBank::Left {
         buffer.push_str(" |B~~~| ");
     } else {
         buffer.push_str(" |~~~B| ");
@@ -284,8 +304,9 @@ pub fn pretty_print_state(state: &WorldState) -> String {
 
 /// Pretty-prints an action
 pub fn pretty_print_action(action: &WorldAction, state: &WorldState) -> String {
-    let mut buffer = String::from("         ");
-    if state.boat == RiverBank::Left {
+    let at_most = (state.left.humans + state.right.humans) as usize;
+    let mut buffer = String::from(" ".repeat(at_most * 2 + 3));
+    if state.boat.bank == RiverBank::Left {
         buffer.push_str("← ");
     }
     buffer.push_str(&"H".repeat(action.humans as _));
@@ -293,7 +314,7 @@ pub fn pretty_print_action(action: &WorldAction, state: &WorldState) -> String {
         buffer.push(' ');
     }
     buffer.push_str(&"Z".repeat(action.zombies as _));
-    if state.boat == RiverBank::Right {
+    if state.boat.bank == RiverBank::Right {
         buffer.push_str(" →");
     }
 
@@ -309,7 +330,7 @@ mod tests {
         let state = WorldState::new(
             RiverBankState::new(2, 2),
             RiverBankState::new(1, 1),
-            RiverBank::Left,
+            Boat::new(2, RiverBank::Left),
         );
 
         let action = WorldAction::new(2, 0).expect("valid action");

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,24 +3,97 @@ mod humans_and_zombies;
 mod search;
 mod strategies;
 
+use crate::humans_and_zombies::{Boat, RiverBank, RiverBankState};
 use crate::search::search;
+use clap::{Arg, ArgMatches, Command};
 use colored::Colorize;
-use std::fmt::Debug;
+
+fn get_matches() -> ArgMatches {
+    let command = Command::new("toy-planning")
+        .subcommand_required(true)
+        .subcommands([Command::new("humans-and-zombies")
+            .arg(
+                Arg::new("humans")
+                    .short('H')
+                    .long("humans")
+                    .help("The number of humans on the river bank")
+                    .default_value("3")
+                    .value_name("COUNT")
+                    .value_parser(parse_nonzero_u8)
+                    .allow_negative_numbers(false)
+                    .num_args(1),
+            )
+            .arg(
+                Arg::new("zombies")
+                    .short('Z')
+                    .long("zombies")
+                    .help("The number of zombies on the river bank")
+                    .default_value("3")
+                    .value_name("COUNT")
+                    .value_parser(parse_nonzero_u8)
+                    .allow_negative_numbers(false)
+                    .num_args(1),
+            )
+            .arg(
+                Arg::new("boat")
+                    .short('B')
+                    .long("boat")
+                    .help("The capacity of the boat")
+                    .default_value("2")
+                    .value_name("COUNT")
+                    .value_parser(parse_nonzero_u8)
+                    .allow_negative_numbers(false)
+                    .num_args(1),
+            )]);
+    command.get_matches()
+}
+
+fn parse_nonzero_u8(value: &str) -> Result<u8, String> {
+    let value = value.parse().map_err(|e| format!("{e:?}"))?;
+    if value == 0 {
+        Err(String::from("value must be positive"))
+    } else {
+        Ok(value)
+    }
+}
 
 fn main() {
-    use humans_and_zombies::{pretty_print_action, pretty_print_state, WorldState};
-    let initial_state = WorldState::default();
+    let matches = get_matches();
+    match matches.subcommand() {
+        Some(("humans-and-zombies", matches)) => {
+            use humans_and_zombies::{pretty_print_action, pretty_print_state, WorldState};
 
-    if let Some(history) = search(initial_state) {
-        println!("\nSolution:\n");
-        for (action, state) in history {
-            if let Some(action) = action {
-                println!("  {}", pretty_print_action(&action, &state).yellow());
+            let humans = matches
+                .get_one::<u8>("humans")
+                .cloned()
+                .expect("value is required");
+            let zombies = matches
+                .get_one::<u8>("zombies")
+                .cloned()
+                .expect("value is required");
+            let boat = matches
+                .get_one::<u8>("boat")
+                .cloned()
+                .expect("value is required");
+
+            let left = RiverBankState::new(humans, zombies);
+            let right = RiverBankState::new(0, 0);
+            let boat = Boat::new(boat, RiverBank::Left);
+            let initial_state = WorldState::new(left, right, boat);
+
+            if let Some(history) = search(initial_state) {
+                println!("\nSolution:\n");
+                for (action, state) in history {
+                    if let Some(action) = action {
+                        println!("  {}", pretty_print_action(&action, &state).yellow());
+                    }
+
+                    println!("  {}", pretty_print_state(&state));
+                }
+            } else {
+                eprintln!("No solution found.");
             }
-
-            println!("  {}", pretty_print_state(&state));
         }
-    } else {
-        eprintln!("No solution found.");
+        _ => {}
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,11 +58,10 @@ fn parse_nonzero_u8(value: &str) -> Result<u8, String> {
 }
 
 fn main() {
-    let matches = get_matches();
-    match matches.subcommand() {
-        Some(("humans-and-zombies", matches)) => {
-            use humans_and_zombies::{pretty_print_action, pretty_print_state, WorldState};
+    use humans_and_zombies::{pretty_print_action, pretty_print_state, WorldState};
 
+    let initial_state = match get_matches().subcommand() {
+        Some(("humans-and-zombies", matches)) => {
             let humans = matches
                 .get_one::<u8>("humans")
                 .cloned()
@@ -79,21 +78,24 @@ fn main() {
             let left = RiverBankState::new(humans, zombies);
             let right = RiverBankState::new(0, 0);
             let boat = Boat::new(boat, RiverBank::Left);
-            let initial_state = WorldState::new(left, right, boat);
-
-            if let Some(history) = search(initial_state) {
-                println!("\nSolution:\n");
-                for (action, state) in history {
-                    if let Some(action) = action {
-                        println!("  {}", pretty_print_action(&action, &state).yellow());
-                    }
-
-                    println!("  {}", pretty_print_state(&state));
-                }
-            } else {
-                eprintln!("No solution found.");
-            }
+            WorldState::new(left, right, boat)
         }
-        _ => {}
+        _ => {
+            unreachable!("Unhandled subcommand")
+        }
+    };
+
+    // TODO: Refactor this part with pretty-printing.
+    if let Some(history) = search(initial_state) {
+        println!("\nSolution:\n");
+        for (action, state) in history {
+            if let Some(action) = action {
+                println!("  {}", pretty_print_action(&action, &state).yellow());
+            }
+
+            println!("  {}", pretty_print_state(&state));
+        }
+    } else {
+        eprintln!("No solution found.");
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,5 +1,5 @@
 use crate::history::History;
-use crate::strategies::Lifo;
+use crate::strategies::{Fifo, Lifo};
 use std::collections::HashSet;
 use std::fmt::Debug;
 
@@ -74,7 +74,7 @@ where
     let mut history = History::new();
     let lineage = history.create_root(initial_state.clone());
 
-    let mut fringe = Lifo::from(lineage);
+    let mut fringe = Fifo::from(lineage);
     while let Some(lineage) = fringe.pop() {
         let state = &lineage.state;
         println!("Exploring state {}: {:?}", lineage.id, state);

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,5 +1,5 @@
 use crate::history::History;
-use crate::strategies::{Fifo, Lifo};
+use crate::strategies::Fifo;
 use std::collections::HashSet;
 use std::fmt::Debug;
 


### PR DESCRIPTION
This adds subcommands for future expansion into different problems, as well as parameterization for the Humans and Zombies problem.

For example, to use only two zombies and a boat with capacity four, one can now run

```
cargo run -- humans-and-zombies --humans 3 --zombies 2 --boat 4
```

Which prints a plan like:

```
   HHH ZZ |B~~~|
           HHH →
       ZZ |~~~B| HHH
           ← HH
    HH ZZ |B~~~| H
           HH ZZ →
          |~~~B| HHH ZZ
```