### PR TITLE
Add the Bridge and Torch problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Added command-line arguments to application.
+- Added the Bridge and Torch problem via the `bridge-and-torch` subcommand.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +167,7 @@ version = "0.2.0-unstable"
 dependencies = [
  "clap",
  "colored",
+ "itertools",
 ]
 
 [[package]]
@@ -184,6 +191,15 @@ dependencies = [
  "io-lifetimes",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ color = ["dep:colored"]
 [dependencies]
 clap = "4.2.7"
 colored = { version = "2.0.0", optional = true }
+itertools = "0.10.5"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ _Nᴏᴡ ᴡɪᴛʜ x﹪ ᴍᴏʀᴇ ᴢᴏᴍʙɪᴇs ᴀɴᴅ ʙʀɪᴅɢᴇs�
 
 ---
 
-Implementation of search-based planning on the [river crossing] type of ~~toy problems~~  puzzles.
+Implementation(s) of search-based planning on the [river crossing] type of ~~toy problems~~ puzzles.
+Since this is really just a playground, the found solutions are not necessarily optimal,
+i.e. shorter or more efficient paths may exist.
 
 ## Humans and Zombies
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
-# Toy Planning: "Humans and Zombies"
-_Nᴏᴡ ᴡɪᴛʜ x﹪ ᴍᴏʀᴇ ᴢᴏᴍʙɪᴇs﹗_
+# Toy Planning: River Crossing
+_Nᴏᴡ ᴡɪᴛʜ x﹪ ᴍᴏʀᴇ ᴢᴏᴍʙɪᴇs ᴀɴᴅ ʙʀɪᴅɢᴇs﹗_
 
 ---
 
-An implementation of search-based planning using the Humans and Zombies problem,
-a version of the [river crossing] problem without the racism of "[Missionaries and Cannibals]"
-and the sexism of "Jealous Husbands".
+Implementation of search-based planning on the [river crossing] type of ~~toy problems~~  puzzles.
+
+## Humans and Zombies
+
+This is the Humans and Zombies problem, a classic version of the river crossing problem without
+the racism of "[Missionaries and Cannibals]" and the sexism of "Jealous Husbands".
 
 The problem statement, paraphrasing Wikipedia, is this:
 
@@ -65,5 +68,41 @@ Which prints a plan like:
 Result plans differ depending on whether a depth-first (LIFO) or
 breadth-first (FIFO) search is used.
 
+## Bridge and Torch
+
+The [Bridge and Torch] problem works as follows:
+
+> Four people come to a river in the night. There is a narrow bridge, but it can only
+> hold two people at a time. They have one torch and, because it's night, the torch has
+> to be used when crossing the bridge.
+> 
+> Person A can cross the bridge in 1 minute, B in 2 minutes, C in 5 minutes, and D in 8 minutes.
+> When two people cross the bridge together, they must move at the slower person's pace.
+> 
+> The question is, can they all get across the bridge if the torch lasts only 15 minutes?
+
+To solve the problem, run:
+
+```
+cargo run -- bridge-and-torch
+```
+
+It prints a solution like the following:
+
+```
+  At 0 minutes: [<1>, <2>, <5>, <8>] on the left, nobody on the right
+   → [<1>, <2>] cross forward, taking 2 minutes
+  At 2 minutes: [<5>, <8>] on the left, [<1>, <2>] on the right
+   ← [<1>] returns, taking 1 minute
+  At 3 minutes: [<5>, <8>, <1>] on the left, [<2>] on the right
+   → [<5>, <8>] cross forward, taking 8 minutes
+  At 11 minutes: [<1>] on the left, [<2>, <5>, <8>] on the right
+   ← [<2>] returns, taking 2 minutes
+  At 13 minutes: [<1>, <2>] on the left, [<5>, <8>] on the right
+   → [<1>, <2>] cross forward, taking 2 minutes
+  At 15 minutes: nobody on the left, [<5>, <8>, <1>, <2>] on the right
+```
+
 [River crossing]: https://en.wikipedia.org/wiki/River_crossing_puzzle
 [Missionaries and Cannibals]: https://en.wikipedia.org/wiki/Missionaries_and_cannibals_problem
+[Bridge and Torch]: https://en.wikipedia.org/wiki/Bridge_and_torch_problem

--- a/README.md
+++ b/README.md
@@ -92,17 +92,17 @@ cargo run -- bridge-and-torch
 It prints a solution like the following:
 
 ```
-  At 0 minutes: [<1>, <2>, <5>, <8>] on the left, nobody on the right
+  At 0 minutes: [<1>, <2>, <5>, <8>] on the left, nobody on the right (torch: 15 minutes)
    → [<1>, <2>] cross forward, taking 2 minutes
-  At 2 minutes: [<5>, <8>] on the left, [<1>, <2>] on the right
+  At 2 minutes: [<5>, <8>] on the left, [<1>, <2>] on the right (torch: 13 minutes)
    ← [<1>] returns, taking 1 minute
-  At 3 minutes: [<5>, <8>, <1>] on the left, [<2>] on the right
+  At 3 minutes: [<5>, <8>, <1>] on the left, [<2>] on the right (torch: 12 minutes)
    → [<5>, <8>] cross forward, taking 8 minutes
-  At 11 minutes: [<1>] on the left, [<2>, <5>, <8>] on the right
+  At 11 minutes: [<1>] on the left, [<2>, <5>, <8>] on the right (torch: 4 minutes)
    ← [<2>] returns, taking 2 minutes
-  At 13 minutes: [<1>, <2>] on the left, [<5>, <8>] on the right
+  At 13 minutes: [<1>, <2>] on the left, [<5>, <8>] on the right (torch: 2 minutes)
    → [<1>, <2>] cross forward, taking 2 minutes
-  At 15 minutes: nobody on the left, [<5>, <8>, <1>, <2>] on the right
+  At 15 minutes: nobody on the left, [<5>, <8>, <1>, <2>] on the right (torch: 0 minutes)
 ```
 
 [River crossing]: https://en.wikipedia.org/wiki/River_crossing_puzzle

--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ The [Bridge and Torch] problem works as follows:
 > 
 > The question is, can they all get across the bridge if the torch lasts only 15 minutes?
 
-To solve the problem, run:
+To solve the problem, run either of these equivalent commands;
 
 ```
 cargo run -- bridge-and-torch
+cargo run -- bridge-and-torch --bridge 2 --torch 15 --person 1 --person 2 --person 5 --person 8
 ```
 
 It prints a solution like the following:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,44 @@ Implementation(s) of search-based planning on the [river crossing] type of ~~toy
 Since this is really just a playground, the found solutions are not necessarily optimal,
 i.e. shorter or more efficient paths may exist.
 
-## Humans and Zombies
+## 🌉+🔦 — The Bridge and Torch Problem
+
+The [Bridge and Torch] problem works as follows:
+
+> Four people come to a river in the night. There is a narrow bridge, but it can only
+> hold two people at a time. They have one torch and, because it's night, the torch has
+> to be used when crossing the bridge.
+>
+> Person A can cross the bridge in 1 minute, B in 2 minutes, C in 5 minutes, and D in 8 minutes.
+> When two people cross the bridge together, they must move at the slower person's pace.
+>
+> The question is, can they all get across the bridge if the torch lasts only 15 minutes?
+
+The problem specifics are encoded in [`bridge_and_torch.rs`](src/bridge_and_torch.rs).
+To solve the problem, run either of these equivalent commands;
+
+```
+cargo run -- bridge-and-torch
+cargo run -- bridge-and-torch --bridge 2 --torch 15 --person 1 --person 2 --person 5 --person 8
+```
+
+It prints a solution like the following:
+
+```
+  At 0 minutes: [<1>, <2>, <5>, <8>] on the left, nobody on the right (torch: 15 minutes)
+   → [<1>, <2>] cross forward, taking 2 minutes
+  At 2 minutes: [<5>, <8>] on the left, [<1>, <2>] on the right (torch: 13 minutes)
+   ← [<1>] returns, taking 1 minute
+  At 3 minutes: [<5>, <8>, <1>] on the left, [<2>] on the right (torch: 12 minutes)
+   → [<5>, <8>] cross forward, taking 8 minutes
+  At 11 minutes: [<1>] on the left, [<2>, <5>, <8>] on the right (torch: 4 minutes)
+   ← [<2>] returns, taking 2 minutes
+  At 13 minutes: [<1>, <2>] on the left, [<5>, <8>] on the right (torch: 2 minutes)
+   → [<1>, <2>] cross forward, taking 2 minutes
+  At 15 minutes: nobody on the left, [<5>, <8>, <1>, <2>] on the right (torch: 0 minutes)
+```
+
+## 🙎+🧟‍ — The Humans and Zombies Problem
 
 This is the Humans and Zombies problem, a classic version of the river crossing problem without
 the racism of "[Missionaries and Cannibals]" and the sexism of "Jealous Husbands".
@@ -20,8 +57,8 @@ The problem statement, paraphrasing Wikipedia, is this:
 > (if they were, the zombies would eat the humans).
 > The boat cannot cross the river by itself with no people on board.
 
-See [`humans_and_zombies.rs`](src/humans_and_zombies.rs) for the problem specifics
-and [`search.rs`](src/search.rs) for the search specifics or simply run `cargo run -- humans-and-zombies` and observe a solution:
+See [`humans_and_zombies.rs`](src/humans_and_zombies.rs) for the problem specifics or
+simply run `cargo run -- humans-and-zombies` and observe a solution:
 
 ```
   HHH ZZZ |B~~~|
@@ -69,42 +106,6 @@ Which prints a plan like:
 
 Result plans differ depending on whether a depth-first (LIFO) or
 breadth-first (FIFO) search is used.
-
-## Bridge and Torch
-
-The [Bridge and Torch] problem works as follows:
-
-> Four people come to a river in the night. There is a narrow bridge, but it can only
-> hold two people at a time. They have one torch and, because it's night, the torch has
-> to be used when crossing the bridge.
-> 
-> Person A can cross the bridge in 1 minute, B in 2 minutes, C in 5 minutes, and D in 8 minutes.
-> When two people cross the bridge together, they must move at the slower person's pace.
-> 
-> The question is, can they all get across the bridge if the torch lasts only 15 minutes?
-
-To solve the problem, run either of these equivalent commands;
-
-```
-cargo run -- bridge-and-torch
-cargo run -- bridge-and-torch --bridge 2 --torch 15 --person 1 --person 2 --person 5 --person 8
-```
-
-It prints a solution like the following:
-
-```
-  At 0 minutes: [<1>, <2>, <5>, <8>] on the left, nobody on the right (torch: 15 minutes)
-   → [<1>, <2>] cross forward, taking 2 minutes
-  At 2 minutes: [<5>, <8>] on the left, [<1>, <2>] on the right (torch: 13 minutes)
-   ← [<1>] returns, taking 1 minute
-  At 3 minutes: [<5>, <8>, <1>] on the left, [<2>] on the right (torch: 12 minutes)
-   → [<5>, <8>] cross forward, taking 8 minutes
-  At 11 minutes: [<1>] on the left, [<2>, <5>, <8>] on the right (torch: 4 minutes)
-   ← [<2>] returns, taking 2 minutes
-  At 13 minutes: [<1>, <2>] on the left, [<5>, <8>] on the right (torch: 2 minutes)
-   → [<1>, <2>] cross forward, taking 2 minutes
-  At 15 minutes: nobody on the left, [<5>, <8>, <1>, <2>] on the right (torch: 0 minutes)
-```
 
 [River crossing]: https://en.wikipedia.org/wiki/River_crossing_puzzle
 [Missionaries and Cannibals]: https://en.wikipedia.org/wiki/Missionaries_and_cannibals_problem

--- a/src/bridge_and_torch.rs
+++ b/src/bridge_and_torch.rs
@@ -1,0 +1,332 @@
+use crate::pretty_print::{PrettyPrintAction, PrettyPrintState};
+use crate::search::{Action, State};
+use itertools::Itertools;
+use std::fmt::{Debug, Formatter};
+
+/// Describes the world state.
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct WorldState {
+    /// The current time.
+    pub time: u8,
+    /// The left river side.
+    pub left: RiverSideState,
+    /// The right river side.
+    pub right: RiverSideState,
+    /// The torch.
+    pub torch: Torch,
+    /// The capacity of the bridge, i.e. how many people it can hold.
+    pub bridge_capacity: u8,
+}
+
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub enum RiverSide {
+    /// The left river side.
+    Left,
+    /// Right right river side.
+    Right,
+}
+
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct Torch {
+    /// The location of the torch.
+    pub side: RiverSide,
+    /// The remaining time the fuel can burn.
+    pub remaining_time: u8,
+}
+
+#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct Person {
+    /// The time it takes for the person to cross the bridge.
+    pub walking_time: u8,
+}
+
+/// Describes the state on a river side.
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct RiverSideState {
+    /// The people on this side.
+    pub people: Vec<Person>,
+}
+
+/// An action to apply.
+#[derive(Clone)]
+pub struct WorldAction {
+    /// The people to move.
+    pub people: Vec<Person>,
+}
+
+impl WorldState {
+    /// Creates a new problem state from the left and right river side states.
+    pub const fn new(
+        left: RiverSideState,
+        right: RiverSideState,
+        torch: Torch,
+        time: u8,
+        bridge_capacity: u8,
+    ) -> Self {
+        Self {
+            left,
+            right,
+            torch,
+            time,
+            bridge_capacity,
+        }
+    }
+
+    /// Unpacks the world state into a (mutable) tuple of "this river side" (i.e.
+    /// the side that the torch is currently at) and "the opposite river side".
+    pub fn here_there_mut(&mut self) -> (&mut RiverSideState, &mut RiverSideState) {
+        match self.torch.side {
+            RiverSide::Left => (&mut self.left, &mut self.right),
+            RiverSide::Right => (&mut self.right, &mut self.left),
+        }
+    }
+
+    /// Gets the river side the torch is at.
+    pub fn torch_side(&self) -> &RiverSideState {
+        match self.torch.side {
+            RiverSide::Left => &self.left,
+            RiverSide::Right => &self.right,
+        }
+    }
+}
+
+impl Default for WorldState {
+    fn default() -> Self {
+        let left = RiverSideState::new(vec![
+            Person::new(1),
+            Person::new(2),
+            Person::new(5),
+            Person::new(8),
+        ]);
+        let right = RiverSideState::new(vec![]);
+        let torch = Torch::new(15, RiverSide::Left);
+        WorldState::new(left, right, torch, 0, 2)
+    }
+}
+
+impl Debug for WorldState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{{ t={}, left: {:?}, right: {:?}, torch: {:?} }}",
+            self.time, self.left, self.right, self.torch
+        )
+    }
+}
+
+impl Person {
+    /// Creates a new person from the number of minutes it takes to cross the bridge.
+    pub const fn new(walking_time: u8) -> Self {
+        Self { walking_time }
+    }
+}
+
+impl Torch {
+    /// Creates a new river side state from the number of humans and zombies.
+    pub const fn new(remaining: u8, side: RiverSide) -> Self {
+        Self {
+            remaining_time: remaining,
+            side,
+        }
+    }
+}
+
+impl RiverSideState {
+    /// Creates a new river side state from the people.
+    pub const fn new(people: Vec<Person>) -> Self {
+        Self { people }
+    }
+
+    /// Determines whether this river side is empty, i.e. contains no people.
+    pub fn is_empty(&self) -> bool {
+        self.people.is_empty()
+    }
+}
+
+impl Debug for Person {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<{}>", self.walking_time)
+    }
+}
+
+impl Debug for RiverSideState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.people)
+    }
+}
+
+impl WorldAction {
+    pub fn new(people: Vec<Person>) -> Self {
+        debug_assert!(!people.is_empty());
+        Self { people }
+    }
+
+    pub fn walking_time(&self) -> u8 {
+        // The effective walking time is determined by the slowest walker, i.e.
+        // the person with the highest walking time.
+        self.people
+            .iter()
+            .map(|p| p.walking_time)
+            .max()
+            .expect("at least one person must walk")
+    }
+}
+
+impl Debug for WorldAction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{ {:?} }}", self.people)
+    }
+}
+
+impl RiverSide {
+    /// Switches from the left side to the right and vice versa.
+    pub fn switch(&self) -> Self {
+        match self {
+            RiverSide::Left => RiverSide::Right,
+            RiverSide::Right => RiverSide::Left,
+        }
+    }
+}
+
+impl State for WorldState {
+    type Action = WorldAction;
+    type Hash = HashState;
+
+    /// Tests whether the specified world state is a goal state.
+    fn is_goal(&self) -> bool {
+        // All zombies and all humans are on the right river side.
+        self.left.is_empty()
+    }
+
+    /// Expands the world state into new (applicable) actions.
+    /// If this state cannot be expanded, an empty vector is returned.
+    fn get_actions(&self) -> Vec<WorldAction> {
+        let mut actions = Vec::with_capacity(5);
+
+        let side = self.torch_side();
+
+        // Move each person over individually.
+        //
+        // We could optimize this by only emitting these actions when we are on
+        // the right river side, as it would generally make no sense for
+        // an individual person to cross left to right since it would have to be the
+        // same person to bring the torch back. The exception to the rule would
+        // be the pathological case of having exactly one person in the puzzle.
+        // For simplicity and symmetry reasons, we still emit all options regardless.
+        //
+        // We simplify the code by trying any unique permutation of people ranging
+        // from one person to the highest number of people. Unique permutations, here,
+        // means that out of the people combination [1, 1, 5] minutes each, only [1, 5]
+        // would be produced as the outcome for trying either [1] person is the same.
+        for c in 1..=self.bridge_capacity {
+            for people in side.people.iter().permutations(c as _).unique() {
+                let action = WorldAction::new(people.into_iter().cloned().collect());
+                if action.is_applicable(self) {
+                    actions.push(action);
+                }
+            }
+        }
+
+        actions
+    }
+
+    /// Gets the hash of this state.
+    fn unique_hash(&self) -> Self::Hash {
+        // The state is fully described by the people that are (still)
+        // on the left side of the bridge and by the torch. Just the
+        // torch location is not enough as multiple paths could lead
+        // to the same people/torch position but different remaining times.
+        HashState {
+            left: self.left.people.clone(),
+            torch: self.torch,
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Hash)]
+pub struct HashState {
+    left: Vec<Person>,
+    torch: Torch,
+}
+
+impl Action for WorldAction {
+    type State = WorldState;
+
+    /// Tests whether an action is applicable in the given (usually current) world state.
+    fn is_applicable(&self, state: &Self::State) -> bool {
+        // We can only cross if the torch holds long enough.
+        state.torch.remaining_time >= self.walking_time()
+    }
+
+    /// Applies the specified action to the specified world state,
+    /// returning the new state after the action was applied.
+    fn apply(&self, state: &Self::State) -> Self::State {
+        let mut state = state.clone();
+        let (here, there) = state.here_there_mut();
+
+        // Move each person from here to there.
+        for person in self.people.iter() {
+            here.people.remove(
+                here.people
+                    .iter()
+                    .position(|x| *x == *person)
+                    .expect("person not found"),
+            );
+            there.people.push(person.clone());
+        }
+
+        let walking_time = self.walking_time();
+        state.time += walking_time;
+        state.torch = Torch::new(
+            state.torch.remaining_time - walking_time,
+            state.torch.side.switch(),
+        );
+        state
+    }
+}
+
+impl PrettyPrintState for WorldState {
+    /// Pretty-prints a world state.
+    fn pretty_print(&self) -> String {
+        format!(
+            "At {} minute{}: {} on the left, {} on the right",
+            self.time,
+            if self.time == 1 { "" } else { "s" },
+            if self.left.is_empty() {
+                "nobody".into()
+            } else {
+                format!("{:?}", self.left)
+            },
+            if self.right.is_empty() {
+                "nobody".into()
+            } else {
+                format!("{:?}", self.right)
+            }
+        )
+    }
+}
+
+impl PrettyPrintAction<WorldState> for WorldAction {
+    /// Pretty-prints an action
+    fn pretty_print(&self, state: &WorldState) -> String {
+        let walking_time = self.walking_time();
+
+        // Note the conditions here are flipped as this represent the state
+        // after the action was applied.
+        match state.torch.side {
+            RiverSide::Right => format!(
+                " → {:?} cross forward, taking {} minute{}",
+                self.people,
+                walking_time,
+                if walking_time == 1 { "" } else { "s" },
+            ),
+            RiverSide::Left => format!(
+                " ← {:?} return{}, taking {} minute{}",
+                self.people,
+                if self.people.len() == 1 { "s" } else { "" },
+                walking_time,
+                if walking_time == 1 { "" } else { "s" },
+            ),
+        }
+    }
+}

--- a/src/bridge_and_torch.rs
+++ b/src/bridge_and_torch.rs
@@ -133,7 +133,7 @@ impl Torch {
 
 impl RiverSideState {
     /// Creates a new river side state from the people.
-    pub const fn new(mut people: Vec<Person>) -> Self {
+    pub const fn new(people: Vec<Person>) -> Self {
         Self { people }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod pretty_print;
 mod search;
 mod strategies;
 
+use crate::bridge_and_torch::RiverSideState;
 use crate::pretty_print::{PrettyPrintAction, PrettyPrintState};
 use crate::search::{search, Action, State};
 use clap::{Arg, ArgMatches, Command};
@@ -89,7 +90,30 @@ fn get_matches() -> ArgMatches {
                         .allow_negative_numbers(false)
                         .num_args(1),
                 ),
-            Command::new("bridge-and-torch").about("The Bridge and Torch problem"),
+            Command::new("bridge-and-torch")
+                .about("The Bridge and Torch problem")
+                .arg(
+                    Arg::new("bridge")
+                        .short('B')
+                        .long("bridge")
+                        .help("The capacity of the bridge")
+                        .default_value("2")
+                        .value_name("COUNT")
+                        .value_parser(parse_nonzero_u8)
+                        .allow_negative_numbers(false)
+                        .num_args(1),
+                )
+                .arg(
+                    Arg::new("torch")
+                        .short('T')
+                        .long("torch")
+                        .help("The capacity of the torch, i.e. how long it will burn")
+                        .default_value("15")
+                        .value_name("MINUTES")
+                        .value_parser(parse_nonzero_u8)
+                        .allow_negative_numbers(false)
+                        .num_args(1),
+                ),
         ]);
     command.get_matches()
 }
@@ -128,7 +152,25 @@ fn humans_and_zombies(matches: &ArgMatches) -> humans_and_zombies::WorldState {
 }
 
 /// Builds the initial state for the Bridge and Torch problem.
-fn bridge_and_torch(_matches: &ArgMatches) -> bridge_and_torch::WorldState {
-    use bridge_and_torch::WorldState;
-    WorldState::default()
+fn bridge_and_torch(matches: &ArgMatches) -> bridge_and_torch::WorldState {
+    use bridge_and_torch::{Person, RiverSide, RiverSideState, Torch, WorldState};
+
+    let bridge = matches
+        .get_one::<u8>("bridge")
+        .cloned()
+        .expect("value is required");
+    let torch = matches
+        .get_one::<u8>("torch")
+        .cloned()
+        .expect("value is required");
+
+    let left = RiverSideState::new(vec![
+        Person::new(1),
+        Person::new(2),
+        Person::new(5),
+        Person::new(8),
+    ]);
+    let right = RiverSideState::new(vec![]);
+    let torch = Torch::new(torch, RiverSide::Left);
+    WorldState::new(left, right, torch, 0, bridge)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod bridge_and_torch;
 mod history;
 mod humans_and_zombies;
 mod pretty_print;
@@ -14,6 +15,7 @@ use std::hash::Hash;
 fn main() {
     let solver = match get_matches().subcommand() {
         Some(("humans-and-zombies", matches)) => run_problem(humans_and_zombies(matches)),
+        Some(("bridge-and-torch", matches)) => run_problem(bridge_and_torch(matches)),
         _ => unreachable!("Unhandled subcommand"),
     };
 
@@ -51,40 +53,44 @@ where
 fn get_matches() -> ArgMatches {
     let command = Command::new("toy-planning")
         .subcommand_required(true)
-        .subcommands([Command::new("humans-and-zombies")
-            .arg(
-                Arg::new("humans")
-                    .short('H')
-                    .long("humans")
-                    .help("The number of humans on the river bank")
-                    .default_value("3")
-                    .value_name("COUNT")
-                    .value_parser(parse_nonzero_u8)
-                    .allow_negative_numbers(false)
-                    .num_args(1),
-            )
-            .arg(
-                Arg::new("zombies")
-                    .short('Z')
-                    .long("zombies")
-                    .help("The number of zombies on the river bank")
-                    .default_value("3")
-                    .value_name("COUNT")
-                    .value_parser(parse_nonzero_u8)
-                    .allow_negative_numbers(false)
-                    .num_args(1),
-            )
-            .arg(
-                Arg::new("boat")
-                    .short('B')
-                    .long("boat")
-                    .help("The capacity of the boat")
-                    .default_value("2")
-                    .value_name("COUNT")
-                    .value_parser(parse_nonzero_u8)
-                    .allow_negative_numbers(false)
-                    .num_args(1),
-            )]);
+        .subcommands([
+            Command::new("humans-and-zombies")
+                .about("The Humans and Zombies problem")
+                .arg(
+                    Arg::new("humans")
+                        .short('H')
+                        .long("humans")
+                        .help("The number of humans on the river bank")
+                        .default_value("3")
+                        .value_name("COUNT")
+                        .value_parser(parse_nonzero_u8)
+                        .allow_negative_numbers(false)
+                        .num_args(1),
+                )
+                .arg(
+                    Arg::new("zombies")
+                        .short('Z')
+                        .long("zombies")
+                        .help("The number of zombies on the river bank")
+                        .default_value("3")
+                        .value_name("COUNT")
+                        .value_parser(parse_nonzero_u8)
+                        .allow_negative_numbers(false)
+                        .num_args(1),
+                )
+                .arg(
+                    Arg::new("boat")
+                        .short('B')
+                        .long("boat")
+                        .help("The capacity of the boat")
+                        .default_value("2")
+                        .value_name("COUNT")
+                        .value_parser(parse_nonzero_u8)
+                        .allow_negative_numbers(false)
+                        .num_args(1),
+                ),
+            Command::new("bridge-and-torch").about("The Bridge and Torch problem"),
+        ]);
     command.get_matches()
 }
 
@@ -119,4 +125,10 @@ fn humans_and_zombies(matches: &ArgMatches) -> humans_and_zombies::WorldState {
     let right = RiverBankState::new(0, 0);
     let boat = Boat::new(boat, RiverBank::Left);
     WorldState::new(left, right, boat)
+}
+
+/// Builds the initial state for the Bridge and Torch problem.
+fn bridge_and_torch(_matches: &ArgMatches) -> bridge_and_torch::WorldState {
+    use bridge_and_torch::WorldState;
+    WorldState::default()
 }


### PR DESCRIPTION
This adds the Bridge and Torch problem. To run, call

```
cargo run -- bridge-and-torch
```

It prints a solution like the following:

```
  At 0 minutes: [<1>, <2>, <5>, <8>] on the left, nobody on the right
   → [<1>, <2>] cross forward, taking 2 minutes
  At 2 minutes: [<5>, <8>] on the left, [<1>, <2>] on the right
   ← [<1>] returns, taking 1 minute
  At 3 minutes: [<5>, <8>, <1>] on the left, [<2>] on the right
   → [<5>, <8>] cross forward, taking 8 minutes
  At 11 minutes: [<1>] on the left, [<2>, <5>, <8>] on the right
   ← [<2>] returns, taking 2 minutes
  At 13 minutes: [<1>, <2>] on the left, [<5>, <8>] on the right
   → [<1>, <2>] cross forward, taking 2 minutes
  At 15 minutes: nobody on the left, [<5>, <8>, <1>, <2>] on the right
```